### PR TITLE
Upgrade to Mongoid 5

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,6 @@
 source 'https://rubygems.org'
 gemspec
 
-gem "mongoid", ">= 3"
-gem "rake"
-
 group :test do
   gem "rspec"
 

--- a/lib/mongoid/uuid/version.rb
+++ b/lib/mongoid/uuid/version.rb
@@ -1,5 +1,5 @@
 module Mongoid
   module Uuid
-    VERSION = '0.0.6'
+    VERSION = "1.0.0"
   end
 end

--- a/mongoid-uuid.gemspec
+++ b/mongoid-uuid.gemspec
@@ -20,7 +20,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'mongoid-uuid'
 
   s.add_runtime_dependency 'uuid', '~> 2.3'
-  s.add_dependency 'mongoid', '>= 3.0'
+  s.add_dependency 'mongoid', '>= 3.0', '< 6'
 
   s.add_development_dependency 'yard'
   s.add_development_dependency 'rake'

--- a/mongoid-uuid.gemspec
+++ b/mongoid-uuid.gemspec
@@ -20,12 +20,12 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'mongoid-uuid'
 
   s.add_runtime_dependency 'uuid', '~> 2.3'
-  s.add_dependency 'yard'
-  s.add_dependency 'rake'
   s.add_dependency 'mongoid', '>= 3.0'
-  s.add_dependency 'rspec', '~> 3.0'
-  s.add_dependency 'mongoid-rspec', '~> 2.0.0.rc1'
 
+  s.add_development_dependency 'yard'
+  s.add_development_dependency 'rake'
+  s.add_development_dependency 'rspec', '~> 3.0'
+  s.add_development_dependency 'mongoid-rspec', '~> 2.0.0.rc1'
 
   s.files = Dir.glob('lib/**/*')# + %w(CHANGELOG.md LICENSE README.md
   s.test_files = Dir.glob('spec/**/*')

--- a/mongoid-uuid.gemspec
+++ b/mongoid-uuid.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'yard'
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3.0'
-  s.add_development_dependency 'mongoid-rspec', '~> 2.0.0.rc1'
+  s.add_development_dependency 'mongoid-rspec', '~> 3.0'
 
   s.files = Dir.glob('lib/**/*')# + %w(CHANGELOG.md LICENSE README.md
   s.test_files = Dir.glob('spec/**/*')


### PR DESCRIPTION
- Separate development dependencies
- Add compatibility with mongoid 5
- Bump version to 1.0 to follow semantic versioning

This gem is now compatible with mongoid 5. In the future, if mongoid ever bumps to version 6, this gem needs to increment a major version.

I would also suggest translating the non english text in the README.
