### PR TITLE
Mongoid 7 compatibility

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake'
-gem 'mongoid', '~> 6.0'
+gem 'mongoid', '~> 7.0'
 
 group :test do
   gem 'rspec'

--- a/mongoid-uuid.gemspec
+++ b/mongoid-uuid.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.rubyforge_project = 'mongoid-uuid'
 
   s.add_dependency 'uuid', '>= 2.3', '< 3'
-  s.add_dependency 'mongoid', '>= 3.0', '< 7'
+  s.add_dependency 'mongoid', '>= 3.0', '< 8'
   s.add_dependency 'rake'
 
   s.add_development_dependency 'yard'


### PR DESCRIPTION
Mongoid is now at version 7.

This PR relaxes mongoid-uuid's dependency restriction to permit use of mongoid 7, against which all specs still pass.