### PR TITLE
Mongoid 8 compatibility

### DIFF
--- a/mongoid-uuid.gemspec
+++ b/mongoid-uuid.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.required_ruby_version = '>= 2.4'
   s.rubyforge_project = 'mongoid-uuid'
 
-  s.add_dependency 'mongoid', '>= 6.0', '< 8'
+  s.add_dependency 'mongoid', '>= 6.0', '< 9'
   s.add_dependency 'uuid', '>= 2.3', '< 3'
 
   s.add_development_dependency 'rspec', '~> 3.0'


### PR DESCRIPTION
Relax mongoid version constraint to allow 8.x - This transitively allows activesupport 7.2.3.1, and addresses CVE-2026-33169, CVE-2026-33170 and CVE-2026-33176.

All tests still pass.